### PR TITLE
Arreglada la hora de las imágenes en evaluar pedido.

### DIFF
--- a/src/Template/Informes/view.ctp
+++ b/src/Template/Informes/view.ctp
@@ -24,9 +24,9 @@ use Cake\Routing\Router;
         <div class="row card-columns">
             <?php if (!empty($informe->images)) { ?>
                 <?php foreach ($informe->images as $images): ?>
-                    <div class="card col-sm-3">
+                    <div class="card col-sm-3 <?= $images->hay_actividad ? __('peligro') : __('sinPeligro'); ?>">
                         <?= $this->Html->link(
-                                $this->Html->image('../files/images/photo/' . $images->photo_dir . '/' . $images->photo, ['class'=>'card-img-top mt-2']), 
+                                $this->Html->image('../files/images/photo/' . $images->photo_dir . '/' . $images->photo, ['class'=>'card-img-top mt-2','title' => $images->hay_actividad ? __('Hay condiciones de riesgo') : __('No hay condiciones de riesgo')]), 
                                 array('controller' => 'Images', 'action' => 'view', $images->id),
                                 array('escape' => false)
                             );

--- a/src/Template/Pedidos/evaluar.ctp
+++ b/src/Template/Pedidos/evaluar.ctp
@@ -39,15 +39,15 @@ use Cake\Routing\Router;
         <div class="row card-columns">
             <?php if (!empty($pedido->images)){ ?>
                 <?php foreach ($pedido->images as $images): ?>
-                    <div class="card col-sm-3">
+                    <div class="card col-sm-3 <?= $images->hay_actividad ? __('peligro') : __('sinPeligro'); ?>">
                         <?= $this->Html->link(
-                            $this->Html->image('../files/images/photo/' . $images->photo_dir . '/' . $images->photo, ['class'=>'card-img-top mt-1']), 
+                            $this->Html->image('../files/images/photo/' . $images->photo_dir . '/' . $images->photo, ['class'=>'card-img-top mt-1','title' => $images->hay_actividad ? __('Hay condiciones de riesgo') : __('No hay condiciones de riesgo')]), 
                             array('controller' => 'Images', 'action' => 'view', $images->id),
                             array('escape' => false)
                         ); 
                         ?>
                         <div class="card-body">
-                            <h6 class="card-title"><?= h($images->created) ?></h5>
+                            <h6 class="card-title"><?= h($images->fecha_hora_imagen) ?></h5>
                         </div>
                     </div>
                 <?php endforeach; ?>


### PR DESCRIPTION
Se agregó el recuadro rojo en las imágenes relacionadas de evaluar pedido y ver informe.

**PLEASE NOTE:**

This is only a issue tracker for issues related to the CakePHP Application Skeleton.
For CakePHP Framework issues please use this [issue tracker](https://github.com/cakephp/cakephp/issues).

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) guidelines when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.